### PR TITLE
fix: stop passing parent to with_span

### DIFF
--- a/lib/span_args.ex
+++ b/lib/span_args.ex
@@ -5,11 +5,10 @@ defmodule SpanArgs do
 
   def new(opts) when is_list(opts) do
     sampler = Keyword.get(opts, :sampler)
-    parent_ctx = OpenTelemetry.Tracer.current_span_ctx()
 
     case sampler do
-      nil -> %{parent: parent_ctx}
-      sampler -> %{parent: parent_ctx, sampler: sampler}
+      nil -> %{}
+      sampler -> %{sampler: sampler}
     end
   end
 end


### PR DESCRIPTION
Fixes #29 

As of opentelemetry_api 0.6, `parent` is no longer accepted as an argument to `with_span`. Passing it results in Dialyzer warnings in client projects.

I was able to upgrade our application to v0.6.0 to test this out, and all seems to work well.