### PR TITLE
Fix `set_status` call

### DIFF
--- a/lib/open_telemetry_decorator.ex
+++ b/lib/open_telemetry_decorator.ex
@@ -57,7 +57,7 @@ defmodule OpenTelemetryDecorator do
         rescue
           e ->
             OpenTelemetry.Span.record_exception(span_ctx, e)
-            OpenTelemetry.Span.set_status(span_ctx, :error)
+            OpenTelemetry.Span.set_status(span_ctx, OpenTelemetry.status(:error))
             raise(e)
         end
       end


### PR DESCRIPTION
According to dialyzer that call breaks the following contract:
```
breaks the contract
(OpenTelemetry.span_ctx(), OpenTelemetry.status()) :: boolean()
```
To create a "status" type, we need to call `OpenTelemtry.status/1`: https://hexdocs.pm/opentelemetry_api/OpenTelemetry.html#status/1