### PR TITLE
Fix missing stacktrace

### DIFF
--- a/lib/open_telemetry_decorator.ex
+++ b/lib/open_telemetry_decorator.ex
@@ -58,7 +58,7 @@ defmodule OpenTelemetryDecorator do
           e ->
             OpenTelemetry.Span.record_exception(span_ctx, e)
             OpenTelemetry.Span.set_status(span_ctx, OpenTelemetry.status(:error))
-            raise(e)
+            reraise e, __STACKTRACE__
         end
       end
     end


### PR DESCRIPTION
I noticed in the exception reporting when using the decorator is missing hug chunck of the stacktrace.

And it is hidden with the following line:

```
Called from: /build/deps/opentelemetry/src/otel_tracer_default.erl in :otel_tracer_default.with_span/5
```

I believe this change will show the original stacktrace and error.