### PR TITLE
Fix validator to remove all atom restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ You can provide span attributes by specifying a list of variable names as atoms.
 
 This list can include...
 
-Any variables (in the top level closure) available when the function exits:
+Any variables (in the top level closure) available when the function exits.
+Note that variables declared as part of a `with` block are in a separate scope so NOT available for `include` attributes
 
 ```elixir
 defmodule MyApp.Math do

--- a/lib/open_telemetry_decorator/validator.ex
+++ b/lib/open_telemetry_decorator/validator.ex
@@ -6,18 +6,16 @@ defmodule OpenTelemetryDecorator.Validator do
       raise(ArgumentError, "span_name must be a non-empty string")
     end
 
-    if not (is_list(attr_keys) and atoms_or_lists_of_atoms_only?(attr_keys)) do
-      raise(ArgumentError, "attr_keys must be a list of atoms, including nested lists of atoms")
+    if not (is_list(attr_keys) and singular_atom_or_list_starts_with_atom?(attr_keys)) do
+      raise(ArgumentError, "attr_keys must be a list of (atom | [atom | list])")
     end
   end
 
-  defp atoms_or_lists_of_atoms_only?(list) when is_list(list) do
-    Enum.all?(list, fn item ->
-      (is_list(item) && atoms_or_lists_of_atoms_only?(item)) or is_atom(item)
+  defp singular_atom_or_list_starts_with_atom?(list) do
+    Enum.all?(list, fn
+      item when is_atom(item) -> true
+      [item | _rest] when is_atom(item) -> true
+      _ -> false
     end)
-  end
-
-  defp atoms_or_lists_of_atoms_only?(item) when is_atom(item) do
-    true
   end
 end

--- a/test/open_telemetry_decorator/validator_test.exs
+++ b/test/open_telemetry_decorator/validator_test.exs
@@ -22,11 +22,17 @@ defmodule OpenTelemetryDecorator.ValidatorTest do
       Validator.validate_args("event", [])
     end
 
-    test "attrs_keys must be atoms" do
+    test "first reference in attrs_keys must be atom" do
       Validator.validate_args("event", [:variable])
+      Validator.validate_args("event", [:variable, [:key1, :key2]])
+      Validator.validate_args("event", [:variable, [:key1, "key2"]])
 
       assert_raise ArgumentError, ~r/^attr_keys/, fn ->
         Validator.validate_args("event", ["variable"])
+      end
+
+      assert_raise ArgumentError, ~r/^attr_keys/, fn ->
+        Validator.validate_args("event", [["variable", :key]])
       end
     end
 


### PR DESCRIPTION
Prior code change allowed for string-key maps in the `include` list but the `Validator` wasn't updated to remove the restriction that "all things must be atoms"