### PR TITLE
Fix nested structs crashes

### DIFF
--- a/test/open_telemetry_decorator/attributes_test.exs
+++ b/test/open_telemetry_decorator/attributes_test.exs
@@ -92,6 +92,14 @@ defmodule OpenTelemetryDecorator.AttributesTest do
       assert Attributes.get([obj: %{id: 1}], [[:obj, :id]]) == [obj_id: 1]
     end
 
+    test "handles nested structs" do
+      obj_with_struct = %{born_on: Date.new!(2000, 1, 1)}
+
+      assert Attributes.get([obj: obj_with_struct], [[:obj, :born_on, :year]]) == [
+               obj_born_on_year: 2000
+             ]
+    end
+
     test "handles flat and nested attributes" do
       attrs = Attributes.get([error: "whoops", obj: %{id: 1}], [:error, [:obj, :id]])
       assert attrs == [{:obj_id, 1}, {:error, "whoops"}]


### PR DESCRIPTION
👋🏽 Hi, we're trying to upgrade to the latest version, however the way the nested structs are handling has an error. Before wouldn't get any error. The exception is:

```
*Struct* does not implement the Access behaviour
```

We have nested structs like:

```
%User{
  account: %Account{id "id"}
}
```

If I try:

```
@decorate trace("my_app.do_something",
              include: [:user, :account, :id]
```

crashes, before version 1.3, the code above would work.

If we call `as_map()` recursively for each key, we can call `get_in` safe to be used.

What do you think?