### PR TITLE
Feature/add expand all maps opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,13 @@ config :open_telemetry_decorator, attr_joiner: "."
 ```
 
 Thanks to @benregn for the examples and inspiration for these two options!
+
+### Changing the default behavior for expanding nested maps
+By default, nested attributes need to be explicitly selected in the `with_span/3` macro (See additional examples to see this in action). However if you want the default behavior across your application to always expand variables that are maps/structs, you can specify the following config
+```elixir
+config :open_telemetry_decorator, expand_maps: true
+```
+
 <!-- MDOC -->
 
 ### Additional Examples
@@ -169,6 +176,20 @@ defmodule MyApp.Worker do
   use OpenTelemetryDecorator
 
   @decorate with_span("my_app.worker.do_work", include: [[:arg1, :count], [:arg2, :count], :total])
+  def do_work(arg1, arg2) do
+    total = some_calculation(arg1.count, arg2.count)
+    {:ok, total}
+  end
+end
+```
+
+Grab all nested map/struct properties:
+
+```elixir
+defmodule MyApp.Worker do
+  use OpenTelemetryDecorator
+
+  @decorate with_span("my_app.worker.do_work", include: [:arg1, :arg2], expand_maps: true)
   def do_work(arg1, arg2) do
     total = some_calculation(arg1.count, arg2.count)
     {:ok, total}

--- a/config/config.exs
+++ b/config/config.exs
@@ -7,10 +7,9 @@
 # General application configuration
 import Config
 
-config :open_telemetry_decorator,
-  attr_prefix: "",
-  attr_joiner: ".",
-  expand_maps: false
+config :open_telemetry_decorator, attr_prefix: ""
+config :open_telemetry_decorator, attr_joiner: "."
+config :open_telemetry_decorator, expand_maps: false
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/config.exs
+++ b/config/config.exs
@@ -7,8 +7,10 @@
 # General application configuration
 import Config
 
-config :open_telemetry_decorator, attr_prefix: ""
-config :open_telemetry_decorator, attr_joiner: "."
+config :open_telemetry_decorator,
+  attr_prefix: "",
+  attr_joiner: ".",
+  expand_all_maps: false
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/config.exs
+++ b/config/config.exs
@@ -10,7 +10,7 @@ import Config
 config :open_telemetry_decorator,
   attr_prefix: "",
   attr_joiner: ".",
-  expand_all_maps: false
+  expand_maps: false
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/lib/open_telemetry_decorator.ex
+++ b/lib/open_telemetry_decorator.ex
@@ -14,7 +14,7 @@ defmodule OpenTelemetryDecorator do
   alias OpenTelemetryDecorator.Attributes
   alias OpenTelemetryDecorator.Validator
 
-  @default_expand_maps Application.compile_env(:open_telemetry_decorator, :expand_maps)
+  @default_expand_maps Application.compile_env(:open_telemetry_decorator, :expand_maps, false)
 
   def trace(span_name, opts \\ [], body, context), do: with_span(span_name, opts, body, context)
 

--- a/lib/open_telemetry_decorator.ex
+++ b/lib/open_telemetry_decorator.ex
@@ -65,7 +65,7 @@ defmodule OpenTelemetryDecorator do
           attrs =
             Kernel.binding()
             |> Keyword.put(:result, result)
-            |> Attributes.get(unquote(include))
+            |> Attributes.get(unquote(include), unquote(expand_all_maps))
             |> Keyword.merge(input_params)
             |> Enum.map(fn {k, v} -> {Atom.to_string(k), v} end)
 

--- a/lib/open_telemetry_decorator.ex
+++ b/lib/open_telemetry_decorator.ex
@@ -14,7 +14,7 @@ defmodule OpenTelemetryDecorator do
   alias OpenTelemetryDecorator.Attributes
   alias OpenTelemetryDecorator.Validator
 
-  @default_expand_all_maps Application.compile_env(:open_telemetry_decorator, :expand_all_maps)
+  @default_expand_maps Application.compile_env(:open_telemetry_decorator, :expand_all_maps)
 
   def trace(span_name, opts \\ [], body, context), do: with_span(span_name, opts, body, context)
 
@@ -42,7 +42,7 @@ defmodule OpenTelemetryDecorator do
   """
   def with_span(span_name, opts \\ [], body, context) do
     include = Keyword.get(opts, :include, [])
-    expand_all_maps = Keyword.get(opts, :expand_maps, @default_expand_all_maps)
+    expand_maps = Keyword.get(opts, :expand_maps, @default_expand_maps)
     Validator.validate_args(span_name, include)
 
     quote location: :keep do
@@ -54,7 +54,7 @@ defmodule OpenTelemetryDecorator do
 
         input_params =
           Kernel.binding()
-          |> Attributes.get(unquote(include), unquote(expand_all_maps))
+          |> Attributes.get(unquote(include), unquote(expand_maps))
           |> Keyword.delete(:result)
 
         Attributes.set(input_params)
@@ -65,7 +65,7 @@ defmodule OpenTelemetryDecorator do
           attrs =
             Kernel.binding()
             |> Keyword.put(:result, result)
-            |> Attributes.get(unquote(include), unquote(expand_all_maps))
+            |> Attributes.get(unquote(include), unquote(expand_maps))
             |> Keyword.merge(input_params)
             |> Enum.map(fn {k, v} -> {Atom.to_string(k), v} end)
 

--- a/lib/open_telemetry_decorator.ex
+++ b/lib/open_telemetry_decorator.ex
@@ -14,7 +14,7 @@ defmodule OpenTelemetryDecorator do
   alias OpenTelemetryDecorator.Attributes
   alias OpenTelemetryDecorator.Validator
 
-  @default_expand_maps Application.compile_env(:open_telemetry_decorator, :expand_all_maps)
+  @default_expand_maps Application.compile_env(:open_telemetry_decorator, :expand_maps)
 
   def trace(span_name, opts \\ [], body, context), do: with_span(span_name, opts, body, context)
 

--- a/lib/open_telemetry_decorator.ex
+++ b/lib/open_telemetry_decorator.ex
@@ -14,6 +14,8 @@ defmodule OpenTelemetryDecorator do
   alias OpenTelemetryDecorator.Attributes
   alias OpenTelemetryDecorator.Validator
 
+  @default_expand_all_maps Application.compile_env(:open_telemetry_decorator, :expand_all_maps)
+
   def trace(span_name, opts \\ [], body, context), do: with_span(span_name, opts, body, context)
 
   @doc """
@@ -40,6 +42,7 @@ defmodule OpenTelemetryDecorator do
   """
   def with_span(span_name, opts \\ [], body, context) do
     include = Keyword.get(opts, :include, [])
+    expand_all_maps = Keyword.get(opts, :expand_maps, @default_expand_all_maps)
     Validator.validate_args(span_name, include)
 
     quote location: :keep do
@@ -51,7 +54,7 @@ defmodule OpenTelemetryDecorator do
 
         input_params =
           Kernel.binding()
-          |> Attributes.get(unquote(include))
+          |> Attributes.get(unquote(include), unquote(expand_all_maps))
           |> Keyword.delete(:result)
 
         Attributes.set(input_params)

--- a/test/open_telemetry_decorator/attributes_test.exs
+++ b/test/open_telemetry_decorator/attributes_test.exs
@@ -156,12 +156,27 @@ defmodule OpenTelemetryDecorator.AttributesTest do
       assert Attributes.get([obj: %{id: 1}], [[:obj, :id]]) == [obj_id: 1]
     end
 
+    test "handles expanding map" do
+      attributes = Attributes.get([obj: %{id: 1, foo: 2}], [:obj], true)
+      assert {:obj_id, 1} in attributes
+      assert {:obj_foo, 2} in attributes
+
+      attributes = Attributes.get([obj: %{id: 1, foo: 2, foop: %{id: 3}}, obj_b: %{id: 4}], [:obj, :obj_b], true)
+      assert {:obj_id, 1} in attributes
+      assert {:obj_foo, 2} in attributes
+      assert {:obj_foop_id, 3} in attributes
+      assert {:obj_b_id, 4} in attributes
+    end
+
     test "handles nested structs" do
       one_level = %SomeStruct{beep: "boop"}
       assert Attributes.get([obj: one_level], [[:obj, :beep]]) == [obj_beep: "boop"]
 
       two_levels = %SomeStruct{failed: %SomeStruct{count: 3}}
       assert Attributes.get([obj: two_levels], [[:obj, :failed, :count]]) == [obj_failed_count: 3]
+
+      # Use expand_all_maps functionality
+      assert Attributes.get([obj: two_levels], [:obj], true) == [obj_failed_count: 3]
     end
 
     test "handles invalid requests for nested structs" do

--- a/test/open_telemetry_decorator/attributes_test.exs
+++ b/test/open_telemetry_decorator/attributes_test.exs
@@ -161,7 +161,13 @@ defmodule OpenTelemetryDecorator.AttributesTest do
       assert {:obj_id, 1} in attributes
       assert {:obj_foo, 2} in attributes
 
-      attributes = Attributes.get([obj: %{id: 1, foo: 2, foop: %{id: 3}}, obj_b: %{id: 4}], [:obj, :obj_b], true)
+      attributes =
+        Attributes.get(
+          [obj: %{id: 1, foo: 2, foop: %{id: 3}}, obj_b: %{id: 4}],
+          [:obj, :obj_b],
+          true
+        )
+
       assert {:obj_id, 1} in attributes
       assert {:obj_foo, 2} in attributes
       assert {:obj_foop_id, 3} in attributes

--- a/test/open_telemetry_decorator_test.exs
+++ b/test/open_telemetry_decorator_test.exs
@@ -39,6 +39,20 @@ defmodule OpenTelemetryDecoratorTest do
         end
       end
 
+      @decorate with_span("Example.find_expand", include: [:user], expand_maps: true)
+      def find_expand(id) do
+        _even = rem(id, 2) == 0
+        user = %{id: id, name: "my user"}
+
+        case id do
+          1 ->
+            {:ok, user}
+
+          error ->
+            {:error, error}
+        end
+      end
+
       @decorate with_span("Example.parse_params", include: [[:params, "id"]])
       def parse_params(params) do
         %{"id" => id} = params
@@ -104,6 +118,12 @@ defmodule OpenTelemetryDecoratorTest do
       Example.find(1)
       assert_receive {:span, span(name: "Example.find", attributes: attrs)}
       assert %{"user_name" => "my user"} = get_span_attributes(attrs)
+    end
+
+    test "handles nested attributes when expand_maps is set" do
+      Example.find_expand(1)
+      assert_receive {:span, span(name: "Example.find_expand", attributes: attrs)}
+      assert %{"user_id" => 1, "user_name" => "my user"} = get_span_attributes(attrs)
     end
 
     test "handles maps with string keys" do


### PR DESCRIPTION
Added ability to recursively expand maps if specified instead of needing to specify exact keys. This behavior is configured to be off by default, but can be turned on via a config. Or it can be specified for a particular `with_span` call as part of the options.

Let me know the thoughts on this functionality.