### PR TITLE
Feature request/proposal: Make extensible how arguments are traced

### DIFF
--- a/lib/open_telemetry_decorator/traceable.ex
+++ b/lib/open_telemetry_decorator/traceable.ex
@@ -1,0 +1,8 @@
+defprotocol OpenTelemetryDecorator.Traceable do
+  @type t :: OpenTelemetryDecorator.Traceable.t()
+
+  @type otlp_value :: number() | String.t() | boolean() | OpenTelemetry.attributes_map()
+
+  @spec otlp_value(t()) :: otlp_value()
+  def otlp_value(value)
+end

--- a/test/open_telemetry_decorator/attributes_test.exs
+++ b/test/open_telemetry_decorator/attributes_test.exs
@@ -190,6 +190,45 @@ defmodule OpenTelemetryDecorator.AttributesTest do
       assert attrs == [{:result_a, "b"}, {:obj_id, 1}]
     end
 
+    test "handles traceable scalar otlp values" do
+      attributes = [date: ~D[2020-01-01], obj: %{checkout: ~D[2021-01-01]}]
+      required_attributes = [:date, [:obj, :checkout]]
+
+      attrs = Attributes.get(attributes, required_attributes)
+
+      assert attrs == [obj_checkout: "2021-01-01", date: "2020-01-01"]
+    end
+
+    test "handles traceable list of otlp key and values" do
+      attributes = [
+        uri: URI.parse("https://example.com"),
+        obj: %{home_page: URI.parse("https://example.com/home")}
+      ]
+
+      required_attributes = [:uri, [:obj, :home_page]]
+
+      attrs = Attributes.get(attributes, required_attributes)
+
+      assert attrs == [
+               obj_home_page_authority: "example.com",
+               obj_home_page_fragment: nil,
+               obj_home_page_host: "example.com",
+               obj_home_page_path: "/home",
+               obj_home_page_port: 443,
+               obj_home_page_query: nil,
+               obj_home_page_scheme: "https",
+               obj_home_page_userinfo: nil,
+               uri_authority: "example.com",
+               uri_fragment: nil,
+               uri_host: "example.com",
+               uri_path: nil,
+               uri_port: 443,
+               uri_query: nil,
+               uri_scheme: "https",
+               uri_userinfo: nil
+             ]
+    end
+
     test "when target value is valid OTLP type, use it" do
       assert [{:val, 42.42}] == Attributes.get([val: 42.42], [:val])
       assert [{:val, true}] == Attributes.get([val: true], [:val])

--- a/test/support/traceable_protocols_examples.ex
+++ b/test/support/traceable_protocols_examples.ex
@@ -1,0 +1,18 @@
+defimpl OpenTelemetryDecorator.Traceable, for: Date do
+  def otlp_value(date), do: Date.to_iso8601(date)
+end
+
+defimpl OpenTelemetryDecorator.Traceable, for: URI do
+  def otlp_value(uri) do
+    [
+      {"authority", uri.authority},
+      {"fragment", uri.fragment},
+      {"host", uri.host},
+      {"path", uri.path},
+      {"port", uri.port},
+      {"query", uri.query},
+      {"scheme", uri.scheme},
+      {"userinfo", uri.userinfo}
+    ]
+  end
+end


### PR DESCRIPTION
Hi, here where where I work we caught ourselves repeating the same
metadata when tracing some arguments. For example:

```elixir
@trace with_span("work.do", include: [[:user, :id], [:user, :country]])
```

We found ourselves wanting some data structures to be reported consistenly
in the same shape. If we don't want "user's id" be traced anymore, we would like
to change in a single place.

So we caught ourselves in our app writing functions like:

```elixir
defmodule User do
# ...
 def otlp_attributes(user) do
   [
     {"user.id", user.id},
     {"user.country", user.country}
   ]
 end
end
```

Then in places we want to trace:

```elixir
  Tracer.set_attributes(User.otlp_attributes(user))
```

Ideally, I think we would be awesome if we could just:

```elixir
  @trace with_span("work.do", include: [:user])
```

And the library would know how to convert that. But how?

Elixir protocols might be a good solution for data!

The user of the library could define how they want to report common
data structures, then the OpenTelemetryLibraryDecorator knowing that data
has implementation, uses it. Otherwise, just retrieve default implementation
(for backwards-compatiblity.)

What do you think about this feature? I personally think it would be very
useful.

I happy to change the protocol name and function interface for something
that would make more sense if you're interested in adding this feature.
