### PR TITLE
Feature/pass opts to with span

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ open_telemetry_decorator-*.tar
 # Intellij nonsense
 .idea/
 *.iml
+.history/

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 elixir 1.15.7-otp-25
-erlang 25.3.1
+erlang 25.3.2.7

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.14.4
+elixir 1.15.7-otp-25
 erlang 25.3.1

--- a/lib/open_telemetry_decorator.ex
+++ b/lib/open_telemetry_decorator.ex
@@ -41,6 +41,8 @@ defmodule OpenTelemetryDecorator do
   def with_span(span_name, opts \\ [], body, context) do
     include = Keyword.get(opts, :include, [])
     kind = get_kind(opts)
+    decorator_attributes = Keyword.get(opts, :attributes, [])
+
     Validator.validate_args(span_name, include)
 
     quote location: :keep do
@@ -69,6 +71,7 @@ defmodule OpenTelemetryDecorator do
 
           # Called functions can mess up Tracer's current span context, so ensure we at least write to ours
           Attributes.set(span_context, attrs)
+          Attributes.set(span_context, unquote(decorator_attributes))
 
           result
         rescue

--- a/test/open_telemetry_decorator/attributes_test.exs
+++ b/test/open_telemetry_decorator/attributes_test.exs
@@ -1,5 +1,5 @@
 defmodule OpenTelemetryDecorator.AttributesTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   use OtelHelper
 
   alias OpenTelemetryDecorator.Attributes

--- a/test/open_telemetry_decorator_test.exs
+++ b/test/open_telemetry_decorator_test.exs
@@ -260,32 +260,32 @@ defmodule OpenTelemetryDecoratorTest do
         use OpenTelemetryDecorator
 
         @decorate with_span("SpanKinds.producer", kind: :producer)
-        def producer() do
+        def producer do
           :ok
         end
 
         @decorate with_span("SpanKinds.consumer", kind: :consumer)
-        def consumer() do
+        def consumer do
           :ok
         end
 
         @decorate with_span("SpanKinds.internal", kind: :internal)
-        def internal() do
+        def internal do
           :ok
         end
 
         @decorate with_span("SpanKinds.client", kind: :client)
-        def client() do
+        def client do
           :ok
         end
 
         @decorate with_span("SpanKinds.server", kind: :server)
-        def server() do
+        def server do
           :ok
         end
 
         @decorate with_span("SpanKinds.invalid", kind: :invalid)
-        def invalid() do
+        def invalid do
           :ok
         end
       end

--- a/test/open_telemetry_decorator_test.exs
+++ b/test/open_telemetry_decorator_test.exs
@@ -1,5 +1,5 @@
 defmodule OpenTelemetryDecoratorTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
   use OtelHelper
 
   doctest OpenTelemetryDecorator

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,3 @@
+Application.stop(:opentelemetry)
+Application.unload(:opentelemetry)
 ExUnit.start()


### PR DESCRIPTION
This does 2 things:
1. There's a race condition in the async tests where the test pid is being overwritten on each setup block. (OtelHelper.otel_pid_reporter is constantly reconfiguring telemetry). Turning async off, and stopping opentelemetry when the tests start resolved the issue
2. We need to be able to set the span.kind attribute (producer/consumer/client/server/internal) in order to get service graphs to be configured in grafana. So we've added kind as an option, and validated the value.
3. We also wanted the ability to set arbitrary span.attributes, so we allowed attributes to be passed in via opts. 
**Note** If the input parameters tried to set a span attribute that was also set via the `attributes` key, the explicitly set values in `attributes` take precedence.