### PR TITLE
Set error on a span with an unhandled :erlang.exit()

### DIFF
--- a/lib/open_telemetry_decorator.ex
+++ b/lib/open_telemetry_decorator.ex
@@ -82,6 +82,10 @@ defmodule OpenTelemetryDecorator do
         e ->
           O11y.record_exception(e)
           reraise e, __STACKTRACE__
+      catch
+        class, reason ->
+          O11y.set_error("#{class}:#{reason}")
+          :erlang.raise(class, reason, __STACKTRACE__)
       after
         O11y.end_span(parent_span)
       end


### PR DESCRIPTION
Hi,

Thanks for a great OTel decorator!

The decorator handles Elixir exceptions and errors well, but in the most general case it's possible that we might call some code (possibly in Erlang) that will just `:erlang.exit/1,2`. In such a case, with the current code, a span is not marked as an error and contains almost no tags, which makes it hard to pinpoint the problem:

![Screenshot 2024-07-03 at 12 52 28](https://github.com/marcdel/open_telemetry_decorator/assets/112145/b7dec107-34ee-40a3-9d7f-a905ab4c486f)

With this PR such a span is correctly marked as an error with `otel.status_description` being set to the Erlang exception class (one of `throw`, `error`, or `exit`) and a reason:

![Screenshot 2024-07-03 at 12 53 00](https://github.com/marcdel/open_telemetry_decorator/assets/112145/c1ea27a4-6a40-44bf-89cd-dc5f0e3302bb)