### PR TITLE
Catch throws, stringify thrown values and exit reasons for reporting

### DIFF
--- a/lib/open_telemetry_decorator.ex
+++ b/lib/open_telemetry_decorator.ex
@@ -90,11 +90,18 @@ defmodule OpenTelemetryDecorator do
           O11y.set_attribute(:exit, :shutdown, namespace: prefix)
 
         :exit, {:shutdown, reason} ->
-          O11y.set_attributes([exit: :shutdown, shutdown_reason: reason], namespace: prefix)
+          O11y.set_attributes(
+            [exit: :shutdown, shutdown_reason: inspect(reason)],
+            namespace: prefix
+          )
 
         :exit, reason ->
-          O11y.set_error("exited: #{reason}")
+          O11y.set_error("exited: #{inspect(reason)}")
           :erlang.raise(:exit, reason, __STACKTRACE__)
+
+        :throw, thrown ->
+          O11y.set_error("uncaught: #{inspect(thrown)}")
+          :erlang.raise(:throw, thrown, __STACKTRACE__)
       after
         O11y.end_span(parent_span)
       end


### PR DESCRIPTION
One more fix to also catch `throw`s and stringify the thrown values or exit reasons. I think it's bulletproof now 🤞