### PR TITLE
Fixes compilation warnings in Elixir 1.18

### DIFF
--- a/lib/open_telemetry_decorator.ex
+++ b/lib/open_telemetry_decorator.ex
@@ -52,7 +52,6 @@ defmodule OpenTelemetryDecorator do
           Kernel.binding(),
           unquote(span_name),
           unquote(dynamic_links),
-          self(),
           unquote(include)
         )
 
@@ -77,7 +76,7 @@ defmodule OpenTelemetryDecorator do
       reraise %ArgumentError{message: "#{target} #{e.message}"}, __STACKTRACE__
   end
 
-  def prepare(binding, span_name, dynamic_links, pid, include) do
+  def prepare(binding, span_name, dynamic_links, include) do
     links =
       binding
       |> Enum.into(%{})
@@ -95,7 +94,7 @@ defmodule OpenTelemetryDecorator do
       |> Keyword.take(include)
       |> O11y.set_attributes(namespace: prefix)
 
-    O11y.set_attributes(pid: pid)
+    O11y.set_attributes(pid: self())
 
     %{
       new_span: new_span,


### PR DESCRIPTION
Currently, the lib causes compilation warnings in Elixir 1.18 when decorating functions that only have a `raise` in the body:

```elixir
    warning: the following pattern will never match:
        result =
          raise RuntimeError.exception(
                  <<"No handler defined for callback ", String.Chars.to_string(name)::binary,
                    ".">>
                )
    because the right-hand side has type:
        none()
    where "name" was given the type:
        # type: dynamic()
        # from: lib/myproject/module.ex:40:25
        %{"name" => name}
    typing violation found at:
    │
  1 │ defmodule MyProject.Module do
    │ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    │
    └─ lib/myproject/module.ex:1: MyProject.Module.fallback_handler/1
```

The decorated function:
```elixir
  defp fallback_handler(%{"name" => name}) do
    raise "No handler defined for callback #{name}."
  end
```

Adding `generated: true` should address the issue, but currently the lib also generates a high amount of code that affects compile-time performance, when you are decorating functions several times. So I took the chance to improve that too.


These changes were recommended by @josevalim. Thank you!! 💜 